### PR TITLE
Add support for stream resources in FinfoMimeTypeDetector::detectMimeType()

### DIFF
--- a/src/FinfoMimeTypeDetector.php
+++ b/src/FinfoMimeTypeDetector.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace League\MimeTypeDetection;
 
 use const FILEINFO_MIME_TYPE;
-
 use const PATHINFO_EXTENSION;
 use finfo;
 
@@ -42,7 +41,7 @@ class FinfoMimeTypeDetector implements MimeTypeDetector, ExtensionLookup
     /**
      * Buffer size to read from streams if no other bufferSampleSize is defined.
      */
-    const STREAM_BUFFER_SAMPLE_SIZE_DEFAULT = 4100;
+    private const STREAM_BUFFER_SAMPLE_SIZE_DEFAULT = 4100;
 
     public function __construct(
         string $magicFile = '',

--- a/src/FinfoMimeTypeDetectorTest.php
+++ b/src/FinfoMimeTypeDetectorTest.php
@@ -101,7 +101,7 @@ class FinfoMimeTypeDetectorTest extends TestCase
     /**
      * @test
      */
-    public function detecting_uses_extensions_when_a_resource_is_presented(): void
+    public function detecting_uses_extensions_when_a_invalid_resource_is_presented(): void
     {
         /** @var resource $handle */
         $handle = fopen(__DIR__ . '/../test_files/flysystem.svg', 'r+');
@@ -110,5 +110,46 @@ class FinfoMimeTypeDetectorTest extends TestCase
         $mimeType = $this->detector->detectMimeType('flysystem.svg', $handle);
 
         $this->assertEquals('image/svg+xml', $mimeType);
+    }
+
+    /**
+     * @test
+     */
+    public function detecting_uses_stream_contents_when_a_valid_resource_is_presented(): void
+    {
+        /** @var resource $handle */
+        $handle = fopen(__DIR__ . '/../test_files/flysystem.svg', 'r+');
+
+        $mimeType = $this->detector->detectMimeType('flysystem.unknown', $handle);
+        fclose($handle);
+
+        $this->assertEquals('image/svg+xml', $mimeType);
+    }
+
+    /**
+     * @test
+     */
+    public function detecting_keeps_stream_contents_positions_unchanged(): void
+    {
+        /** @var resource $handle */
+        $handle = fopen(__DIR__ . '/../test_files/flysystem.svg', 'r+');
+        fseek($handle, 10);
+        $mimeType = $this->detector->detectMimeType('flysystem.unknown', $handle);
+        $this->assertEquals('image/svg+xml', $mimeType);
+        $this->assertEquals(10, ftell($handle));
+        fclose($handle);
+    }
+
+    /**
+     * @test
+     */
+    public function detecting_non_seekable_streams_are_not_sampling(): void
+    {
+        /** @var resource $handle */
+        $handle = fopen('https://github.com/thephpleague/mime-type-detection', 'r');
+        $mimeType = $this->detector->detectMimeType('flysystem.unknown', $handle);
+        $this->assertEquals(null, $mimeType);
+        $this->assertEquals(0, ftell($handle));
+        fclose($handle);
     }
 }


### PR DESCRIPTION
copied patch in our fork from @das-peter:
As far as I can tell it is valid to call that method with a resource. As such I think it's worth to attempt to detect the mime-type by the stream contents too.
This should be viable via stream_get_contents() while maintaining the stream pointers using ftell() and fseek().