### PR TITLE
Add support for stream resources in FinfoMimeTypeDetector::detectMimeType() for patching

### DIFF
--- a/src/FinfoMimeTypeDetector.php
+++ b/src/FinfoMimeTypeDetector.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace League\MimeTypeDetection;
 
 use const FILEINFO_MIME_TYPE;
-
 use const PATHINFO_EXTENSION;
 use finfo;
 
@@ -39,6 +38,11 @@ class FinfoMimeTypeDetector implements MimeTypeDetector, ExtensionLookup
      */
     private $inconclusiveMimetypes;
 
+    /**
+     * Buffer size to read from streams if no other bufferSampleSize is defined.
+     */
+    private const STREAM_BUFFER_SAMPLE_SIZE_DEFAULT = 4100;
+
     public function __construct(
         string $magicFile = '',
         ExtensionToMimeTypeMap $extensionMap = null,
@@ -53,9 +57,17 @@ class FinfoMimeTypeDetector implements MimeTypeDetector, ExtensionLookup
 
     public function detectMimeType(string $path, $contents): ?string
     {
-        $mimeType = is_string($contents)
-            ? (@$this->finfo->buffer($this->takeSample($contents)) ?: null)
-            : null;
+        $mimeType = null;
+        if (is_string($contents)) {
+            $mimeType = @$this->finfo->buffer($this->takeSample($contents));
+        } elseif (
+            is_resource($contents)
+            && get_resource_type($contents) === 'stream'
+            && ($streamMetaData = stream_get_meta_data($contents))
+            && !empty($streamMetaData['seekable'])
+        ) {
+            $mimeType = @$this->finfo->buffer($this->takeResourceSample($contents));
+        }
 
         if ($mimeType !== null && ! in_array($mimeType, $this->inconclusiveMimetypes)) {
             return $mimeType;
@@ -88,6 +100,37 @@ class FinfoMimeTypeDetector implements MimeTypeDetector, ExtensionLookup
         }
 
         return (string) substr($contents, 0, $this->bufferSampleSize);
+    }
+
+    /**
+     * Fetches a sample of a resource while maintaining its pointer.
+     */
+    private function takeResourceSample($contents): string
+    {
+        if (is_resource($contents) && get_resource_type($contents) === 'stream') {
+            // Memory optimization: given a length stream_get_contents()
+            // immediately allocates an internal buffer.
+            // However, stream_copy_to_stream() reads up to the defined length
+            // without pre-allocating any extra buffer.
+            // Given the relatively large STREAM_BUFFER_SAMPLE_SIZE_DEFAULT this
+            // avoids unnecessary memory hogging.
+            $streamContentBuffer = fopen('php://temp/maxmemory:' . self::STREAM_BUFFER_SAMPLE_SIZE_DEFAULT, 'w+b');
+
+            $streamPosition = ftell($contents);
+            rewind($contents);
+            stream_copy_to_stream(
+                $contents,
+                $streamContentBuffer,
+                $this->bufferSampleSize ?? self::STREAM_BUFFER_SAMPLE_SIZE_DEFAULT,
+                0
+            );
+            rewind($streamContentBuffer);
+            $streamSample = stream_get_contents($streamContentBuffer);
+            fclose($streamContentBuffer);
+            fseek($contents, $streamPosition);
+            return $streamSample;
+        }
+        return '';
     }
 
     public function lookupExtension(string $mimetype): ?string


### PR DESCRIPTION
copied patch in our fork from @das-peter but only the source file without test class change to allow using this as patch as long as it is not merged in the original repository

comment from @das-peter:
As far as I can tell it is valid to call that method with a resource. As such I think it's worth to attempt to detect the mime-type by the stream contents too.
This should be viable via stream_get_contents() while maintaining the stream pointers using ftell() and fseek().
